### PR TITLE
fix README: isUsingFlatlist is true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ render(){
 | renderFullLine         | bool                                | false                      | render event border on last timeline item                        |
 | options                | object                              | null                       | ListView properties                                              |
 | showTime               | boolean                             | true                       | Time container options                                           |
-| isUsingFlatlist        | boolean                             | false                      | Render inner components in Flatlist (if false - render in View)  |
+| isUsingFlatlist        | boolean                             | true                       | Render inner components in Flatlist (if false - render in View)  |
 
 ## Shift problem
 


### PR DESCRIPTION
The default value is `true`, but it is incorrectly mentioned as `false` in the README