### PR TITLE
When not using FlatList, honor keyExtractor & container styles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ export default class Timeline extends PureComponent {
       this.props.renderCircle ? this.props.renderCircle : this._renderCircle
     ).bind(this);
     this.renderEvent = this._renderEvent.bind(this);
+    this._keyExtractor = this._keyExtractor.bind(this);
 
     this.state = {
       data: this.props.data,
@@ -53,6 +54,13 @@ export default class Timeline extends PureComponent {
     return null;
   }
 
+  _keyExtractor(item, index) {
+    if (this.props.options && this.props.options.keyExtractor) {
+      return this.props.options.keyExtractor(item, index);
+    }
+    return index + "";
+  }
+
   render() {
     return (
       <View style={[styles.container, this.props.style]}>
@@ -63,13 +71,22 @@ export default class Timeline extends PureComponent {
             data={this.state.data}
             extraData={this.state}
             renderItem={this._renderItem}
-            keyExtractor={(item, index) => index + ""}
+            keyExtractor={this._keyExtractor}
             {...this.props.options}
           />
         ) : (
-          this.state.data.map((item, index) => (
-            <View key={index + ""}>{this._renderItem({ item, index })}</View>
-          ))
+          <View
+            style={[
+              styles.listview,
+              this.props.listViewStyle,
+              this.props.listViewContainerStyle
+            ]}>
+            {this.state.data.map((item, index) => (
+              <View key={this._keyExtractor(item, index)}>
+                {this._renderItem({ item, index })}
+              </View>
+            ))}
+          </View>
         )}
       </View>
     );


### PR DESCRIPTION
The `isUsingFlatList` flag missed honoring `keyExtractor` & container styles. This PR fixes that.