### PR TITLE
Fix incorrect dot borderRadius calculation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -283,7 +283,7 @@ class Timeline extends PureComponent {
                 const dotStyle = {
                     height: dotSize,
                     width: dotSize,
-                    borderRadius: circleSize / 4,
+                    borderRadius: dotSize / 2,
                     backgroundColor: rowData.dotColor ?? this.props.dotColor ?? defaultDotColor,
                 };
                 innerCircle = <View style={[styles.dot, dotStyle]}/>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -487,7 +487,7 @@ export default class Timeline extends PureComponent<TimelineProps, TimelineState
         const dotStyle: ViewStyle = {
           height: dotSize,
           width: dotSize,
-          borderRadius: circleSize / 4,
+          borderRadius: dotSize / 2,
           backgroundColor:
             rowData.dotColor ?? this.props.dotColor ?? defaultDotColor,
         };


### PR DESCRIPTION
Fixes #89. The dot style borderRadius was incorrectly calculated as circleSize / 4 instead of dotSize / 2. This caused dots to not render as proper circles when custom dotSize values were used. Changed to use dotSize / 2 to correctly create circular dots.